### PR TITLE
Fix Words page error handling and test

### DIFF
--- a/frontend/src/pages/Words.test.tsx
+++ b/frontend/src/pages/Words.test.tsx
@@ -1,10 +1,17 @@
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
-import Words from '@/pages/Words';
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import Words from '@/pages/Words'
 
 describe('Words page', () => {
-  it('renders the page title', () => {
-    render(<Words />);
-    expect(screen.getByText('Words')).toBeInTheDocument();
-  });
-});
+  it('renders the page title', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    } as Response)
+
+    render(<Words />)
+    expect(await screen.findByText('Words')).toBeInTheDocument()
+
+    vi.restoreAllMocks()
+  })
+})

--- a/frontend/src/pages/Words.tsx
+++ b/frontend/src/pages/Words.tsx
@@ -36,98 +36,6 @@ export default function Words() {
       const data: Word[] = await response.json()
       setWords(data)
     } catch (e: unknown) {
-      setError((e as Error).message) finally {
-      setLoading(false)
-    }
-  }
-
-  // Add a new word
-  const addWord = async () => {
-    if (!newEnglishWord || !newVietnameseWord) {
-      alert("English and Vietnamese words are required.")
-      return
-    }
-    try {
-      const response = await fetch(`${API_BASE_URL}/words`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          english: newEnglishWord,
-          vietnamese: newVietnameseWord,
-          example: newExample,
-        }),
-      })
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`)
-      }
-      const addedWord: Word = await response.json()
-      setWords((prevWords) => [...prevWords, addedWord])
-      setNewEnglishWord("")
-      setNewVietnameseWord("")
-      setNewExample("")
-    } catch (e: unknown) {
-      setError((e as Error).message)
-  }
-
-  // Start editing a word
-  const startEditing = (word: Word) => {
-    setEditingWordId(word.id)
-    setEditedEnglishWord(word.english)
-    setEditedVietnameseWord(word.vietnamese)
-    setEditedExample(word.example || "")
-  }
-
-  // Update an existing word
-  const updateWord = async (id: number) => {
-    if (!editedEnglishWord || !editedVietnameseWord) {
-      alert("English and Vietnamese words are required for update.")
-      return
-    }
-    try {
-      const response = await fetch(`${API_BASE_URL}/words/${id}`, {
-        method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          id: id,
-          english: editedEnglishWord,
-          vietnamese: editedVietnameseWord,
-          example: editedExample,
-        }),
-      })
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`)
-      }
-      const updatedWord: Word = await response.json()
-      setWords((prevWords) =>
-        prevWords.map((word) => (word.id === id ? updatedWord : word))
-      )
-      setEditingWordId(null)
-      setEditedEnglishWord("")
-      setEditedVietnameseWord("")
-      setEditedExample("")
-    } catch (e: unknown) {
-      setError((e as Error).message)
-  }
-
-  // Delete a word
-  const deleteWord = async (id: number) => {
-    try {
-      const response = await fetch(`${API_BASE_URL}/words/${id}`, {
-        method: "DELETE",
-      })
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`)
-      }
-      setWords((prevWords) => prevWords.filter((word) => word.id !== id))
-    } catch (e: unknown) {
-      setError((e as Error).message)
-  }
-
-  } catch (e: unknown) {
       setError((e as Error).message)
     } finally {
       setLoading(false)
@@ -172,6 +80,7 @@ export default function Words() {
     setEditedVietnameseWord(word.vietnamese)
     setEditedExample(word.example || "")
   }
+
   // Update an existing word
   const updateWord = async (id: number) => {
     if (!editedEnglishWord || !editedVietnameseWord) {


### PR DESCRIPTION
## Summary
- restore clean Words page implementation with proper error type casting
- update Words page test to mock fetch and wait for title

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `go test ./...` *(no output)*
- `go vet ./...` *(no output)*

------
https://chatgpt.com/codex/tasks/task_b_6891021f40e88323bb8f750623e98297