### PR TITLE
Use configurable API base URL and expose backend on port 8090

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     build:
       context: ./backend
     ports:
-      - "8081:8080"
+      - "8090:8080"
     env_file:
       - .env
     depends_on:

--- a/frontend/src/Game.tsx
+++ b/frontend/src/Game.tsx
@@ -6,6 +6,9 @@ interface Word {
   vi: string;
 }
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ||
+  'http://localhost:8090/api/v1';
+
 export default function Game() {
   const [level, setLevel] = useState<Difficulty | null>(null);
   const [words, setWords] = useState<Word[]>([]);
@@ -18,7 +21,7 @@ export default function Game() {
   const target = level && level >= 4 ? 10 : 5;
 
   useEffect(() => {
-    fetch('http://localhost:8080/api/v1/words')
+    fetch(`${API_BASE_URL}/words`)
       .then((res) => res.json())
       .then((data: Word[]) => {
         setWords(data);


### PR DESCRIPTION
## Summary
- Read API base URL from Vite env and default to backend on port 8090
- Map backend service to port 8090 to align with frontend default

## Testing
- `cd backend && go test ./...`
- `cd frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68918d41cdc8832394120979e29cc7ba