### PR TITLE
fix: adjust base styles for shadcn ui

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -68,11 +68,12 @@
 
 @layer base {
   * {
-    @apply border-border;
+    border-color: hsl(var(--border));
   }
 
   body {
-    @apply bg-background text-foreground;
+    background-color: hsl(var(--background));
+    color: hsl(var(--foreground));
   }
 }
  


### PR DESCRIPTION
## Summary
- ensure shadcn ui base styles don't use Tailwind `@apply` utilities that fail in Tailwind v4

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6891ac353ef48323879c7789245d7e3c