### PR TITLE
Standardize ports except backend 8180

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -21,8 +21,8 @@ WORKDIR /root/
 # Copy the built executable from the builder stage
 COPY --from=builder /main .
 
-# Expose port 8080
-EXPOSE 8080
+# Expose port 8180
+EXPOSE 8180
 
 # Run the application
 CMD ["./main"]

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -35,8 +35,8 @@ func main() {
 		})
 	})
 
-	log.Println("Starting server on :8090")
-	if err := http.ListenAndServe(":8090", r); err != nil {
+	log.Println("Starting server on :8180")
+	if err := http.ListenAndServe(":8180", r); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -3,7 +3,7 @@ info:
   title: English Vocabulary Trainer API
   version: 1.0.0
 servers:
-  - url: http://localhost:8090/api/v1
+  - url: http://localhost:8180/api/v1
 paths:
   /register:
     post:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     build:
       context: ./backend
     ports:
-      - "8090:8080"
+      - "8180:8180"
     env_file:
       - .env
     depends_on:
@@ -28,7 +28,7 @@ services:
   postgres:
     image: bitnami/postgresql:latest
     ports:
-      - "54321:5432"
+      - "5432:5432"
     environment:
       POSTGRESQL_USERNAME: user
       POSTGRESQL_PASSWORD: password

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -12,7 +12,7 @@ This folder contains the React + TypeScript client for the English Vocabulary Tr
 
 ## Environment
 
-The frontend reads `VITE_API_BASE_URL` to know where to send API requests. It defaults to `http://localhost:8080/api/v1`. Create a `.env` file at the project root to override this value if needed.
+The frontend reads `VITE_API_BASE_URL` to know where to send API requests. It defaults to `http://localhost:8180/api/v1`. Create a `.env` file at the project root to override this value if needed.
 
 ## Project Structure
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,5 +1,5 @@
 const API_BASE_URL =
-  import.meta.env.VITE_API_BASE_URL || 'http://localhost:8090/api/v1';
+  import.meta.env.VITE_API_BASE_URL || 'http://localhost:8180/api/v1';
 
 export async function register(username: string, password: string) {
   const res = await fetch(`${API_BASE_URL}/register`, {


### PR DESCRIPTION
Update service port configurations to standardize values, setting the backend to 8180.

---
<a href="https://cursor.com/background-agent?bcId=bc-18c1c44e-6d03-4f0f-a139-41acdede8931">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-18c1c44e-6d03-4f0f-a139-41acdede8931">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

