### PR TITLE
Add router-based pages and toast error handling

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,8 @@
         "lucide-react": "^0.536.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-hot-toast": "^2.6.0",
+        "react-router-dom": "^7.8.1",
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^4.1.11"
       },
@@ -2841,6 +2843,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2860,7 +2871,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -3347,6 +3357,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
       }
     },
     "node_modules/graceful-fs": {
@@ -4148,6 +4167,23 @@
         "react": "^19.1.1"
       }
     },
+    "node_modules/react-hot-toast": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
+      "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -4203,6 +4239,44 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.1.tgz",
+      "integrity": "sha512-5cy/M8DHcG51/KUIka1nfZ2QeylS4PJRs6TT8I4PF5axVsI5JUxp0hC0NZ/AEEj8Vw7xsEoD7L/6FY+zoYaOGA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.8.1.tgz",
+      "integrity": "sha512-NkgBCF3sVgCiAWIlSt89GR2PLaksMpoo3HDCorpRfnCEfdtRPLiuTf+CNXvqZMI5SJLZCLpVCvcZrTdtGW64xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/react-style-singleton": {
@@ -4326,6 +4400,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,8 @@
     "lucide-react": "^0.536.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-hot-toast": "^2.6.0",
+    "react-router-dom": "^7.8.1",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.11"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,6 @@
 import { useState } from 'react';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { Toaster } from 'react-hot-toast';
 import Game from '@/Game';
 import Login from '@/Login';
 import Register from '@/Register';
@@ -8,33 +10,35 @@ import { ThemeProvider } from '@/components/theme-provider';
 
 export default function App() {
   const [userId, setUserId] = useState<number | null>(null);
-  const [view, setView] = useState<'login' | 'register' | 'game' | 'history'>(
-    'login',
-  );
 
   function handleLoggedIn(id: number) {
     setUserId(id);
-    setView('game');
   }
 
   return (
-    <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
-      <ModeToggle />
-      {view === 'login' && (
-        <Login onLogin={handleLoggedIn} onSwitch={() => setView('register')} />
-      )}
-      {view === 'register' && (
-        <Register
-          onRegister={handleLoggedIn}
-          onSwitch={() => setView('login')}
-        />
-      )}
-      {view === 'game' && userId !== null && (
-        <Game userId={userId} onShowHistory={() => setView('history')} />
-      )}
-      {view === 'history' && userId !== null && (
-        <History userId={userId} onBack={() => setView('game')} />
-      )}
-    </ThemeProvider>
+    <BrowserRouter>
+      <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
+        <ModeToggle />
+        <Toaster position="top-center" />
+        <Routes>
+          <Route path="/login" element={<Login onLogin={handleLoggedIn} />} />
+          <Route path="/register" element={<Register onRegister={handleLoggedIn} />} />
+          <Route
+            path="/game"
+            element={
+              userId !== null ? <Game userId={userId} /> : <Navigate to="/login" />
+            }
+          />
+          <Route
+            path="/history"
+            element={
+              userId !== null ? <History userId={userId} /> : <Navigate to="/login" />
+            }
+          />
+          <Route path="/" element={<Navigate to="/login" />} />
+          <Route path="*" element={<Navigate to="/login" />} />
+        </Routes>
+      </ThemeProvider>
+    </BrowserRouter>
   );
 }

--- a/frontend/src/Game.tsx
+++ b/frontend/src/Game.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft } from 'lucide-react';
@@ -11,10 +12,9 @@ import { fetchRandomWords, submitAnswer, createSession } from '@/lib/api';
 
 interface Props {
   userId: number;
-  onShowHistory: () => void;
 }
 
-export default function Game({ userId, onShowHistory }: Props) {
+export default function Game({ userId }: Props) {
   const [level, setLevel] = useState<Difficulty | null>(null);
   const [words, setWords] = useState<Word[]>([]);
   const [current, setCurrent] = useState<Word | null>(null);
@@ -24,6 +24,7 @@ export default function Game({ userId, onShowHistory }: Props) {
   const [feedback, setFeedback] = useState<'correct' | 'incorrect' | ''>('');
   const [feedbackAnswer, setFeedbackAnswer] = useState('');
   const [feedbackKey, setFeedbackKey] = useState(0);
+  const navigate = useNavigate();
 
   const target = level && level >= 4 ? 10 : 5;
 
@@ -136,7 +137,7 @@ export default function Game({ userId, onShowHistory }: Props) {
           <ArrowLeft />
         </Button>
         <Button
-          onClick={onShowHistory}
+          onClick={() => navigate('/history')}
           variant="ghost"
           size="sm"
           className="absolute top-[10px] right-[10px]"

--- a/frontend/src/History.tsx
+++ b/frontend/src/History.tsx
@@ -1,15 +1,16 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { fetchHistory } from '@/lib/api';
 import type { Play } from '@/types';
 
 interface Props {
   userId: number;
-  onBack: () => void;
 }
 
-export default function History({ userId, onBack }: Props) {
+export default function History({ userId }: Props) {
   const [plays, setPlays] = useState<Play[]>([]);
+  const navigate = useNavigate();
 
   useEffect(() => {
     fetchHistory(userId)
@@ -19,7 +20,7 @@ export default function History({ userId, onBack }: Props) {
 
   return (
     <div className="p-4 space-y-4">
-      <Button onClick={onBack}>Back</Button>
+      <Button onClick={() => navigate('/game')}>Back</Button>
       <ul className="space-y-2">
         {plays.map((p) => (
           <li key={p.play_id} className="border p-2 rounded">

--- a/frontend/src/Login.tsx
+++ b/frontend/src/Login.tsx
@@ -1,55 +1,61 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'react-hot-toast';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { login } from '@/lib/api';
 
 interface Props {
   onLogin: (id: number) => void;
-  onSwitch: () => void;
 }
 
-export default function Login({ onLogin, onSwitch }: Props) {
+export default function Login({ onLogin }: Props) {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
+  const navigate = useNavigate();
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     try {
       const user = await login(username, password);
       onLogin(user.user_id);
-    } catch {
-      alert('Login failed');
+      navigate('/game');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Login failed';
+      toast.error(message);
     }
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4 p-4">
-      <div>
-        <Input
-          placeholder="Username"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
-        />
-      </div>
-      <div>
-        <Input
-          type="password"
-          placeholder="Password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
-      </div>
-      <Button type="submit" className="w-full">
-        Login
-      </Button>
-      <Button
-        type="button"
-        variant="link"
-        className="w-full"
-        onClick={onSwitch}
-      >
-        Register
-      </Button>
-    </form>
+    <div className="flex items-center justify-center h-screen">
+      <form onSubmit={handleSubmit} className="space-y-4 p-4">
+        <div>
+          <Input
+            placeholder="Username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+          />
+        </div>
+        <div>
+          <Input
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </div>
+        <Button type="submit" className="w-full">
+          Login
+        </Button>
+        <Button
+          type="button"
+          variant="link"
+          className="w-full"
+          onClick={() => navigate('/register')}
+        >
+          Register
+        </Button>
+      </form>
+    </div>
   );
 }

--- a/frontend/src/Register.tsx
+++ b/frontend/src/Register.tsx
@@ -1,55 +1,61 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'react-hot-toast';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { register } from '@/lib/api';
 
 interface Props {
   onRegister: (id: number) => void;
-  onSwitch: () => void;
 }
 
-export default function Register({ onRegister, onSwitch }: Props) {
+export default function Register({ onRegister }: Props) {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
+  const navigate = useNavigate();
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     try {
       const user = await register(username, password);
       onRegister(user.user_id);
-    } catch {
-      alert('Register failed');
+      navigate('/game');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Register failed';
+      toast.error(message);
     }
   }
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-4 p-4">
-      <div>
-        <Input
-          placeholder="Username"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
-        />
-      </div>
-      <div>
-        <Input
-          type="password"
-          placeholder="Password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
-      </div>
-      <Button type="submit" className="w-full">
-        Register
-      </Button>
-      <Button
-        type="button"
-        variant="link"
-        className="w-full"
-        onClick={onSwitch}
-      >
-        Login
-      </Button>
-    </form>
+    <div className="flex items-center justify-center h-screen">
+      <form onSubmit={handleSubmit} className="space-y-4 p-4">
+        <div>
+          <Input
+            placeholder="Username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+          />
+        </div>
+        <div>
+          <Input
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </div>
+        <Button type="submit" className="w-full">
+          Register
+        </Button>
+        <Button
+          type="button"
+          variant="link"
+          className="w-full"
+          onClick={() => navigate('/login')}
+        >
+          Login
+        </Button>
+      </form>
+    </div>
   );
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -8,7 +8,10 @@ export async function register(username: string, password: string) {
     credentials: 'include',
     body: JSON.stringify({ username, password }),
   });
-  if (!res.ok) throw new Error('register failed');
+  if (!res.ok) {
+    const data = await res.json().catch(() => null);
+    throw new Error(data?.message || data?.error || 'register failed');
+  }
   return res.json();
 }
 
@@ -19,7 +22,10 @@ export async function login(username: string, password: string) {
     credentials: 'include',
     body: JSON.stringify({ username, password }),
   });
-  if (!res.ok) throw new Error('login failed');
+  if (!res.ok) {
+    const data = await res.json().catch(() => null);
+    throw new Error(data?.message || data?.error || 'login failed');
+  }
   return res.json();
 }
 


### PR DESCRIPTION
## Summary
- replace view switching with React Router and add toaster for notifications
- center login and registration forms and navigate between pages
- surface backend auth errors through toast messages

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a158998d888323b3b3603d82a26425