### PR TITLE
Group history by session and highlight answers

### DIFF
--- a/frontend/src/components/history/History.tsx
+++ b/frontend/src/components/history/History.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { fetchHistory } from '@/lib/api';
+import { cn } from '@/lib/utils';
 import type { Play } from '@/types';
 
 interface Props {
@@ -9,26 +10,47 @@ interface Props {
 }
 
 export default function History({ userId }: Props) {
-  const [plays, setPlays] = useState<Play[]>([]);
+  const [sessions, setSessions] = useState<Record<string, Play[]>>({});
   const navigate = useNavigate();
 
   useEffect(() => {
     fetchHistory(userId)
-      .then(setPlays)
+      .then((data: Play[]) => {
+        const grouped: Record<string, Play[]> = {};
+        for (const p of data) {
+          (grouped[p.session_tag] ||= []).push(p);
+        }
+        setSessions(grouped);
+      })
       .catch(() => {});
   }, [userId]);
 
   return (
     <div className="p-4 space-y-4">
       <Button onClick={() => navigate('/game')}>Back</Button>
-      <ul className="space-y-2">
-        {plays.map((p) => (
-          <li key={p.play_id} className="border p-2 rounded">
-            Word ID {p.word_id} - Your answer: {p.user_answer} -{' '}
-            {p.is_correct ? 'Correct' : 'Incorrect'}
-          </li>
-        ))}
-      </ul>
+      {Object.entries(sessions).map(([tag, plays]) => (
+        <div key={tag} className="space-y-2">
+          <h3 className="font-semibold">
+            Session {new Date(plays[0].played_at).toLocaleString()}
+          </h3>
+          <ul className="space-y-2">
+            {plays.map((p) => (
+              <li
+                key={p.play_id}
+                className={cn(
+                  'border p-2 rounded',
+                  p.is_correct
+                    ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100'
+                    : 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-100',
+                )}
+              >
+                Word ID {p.word_id} - Your answer: {p.user_answer} -{' '}
+                {p.is_correct ? 'Correct' : 'Incorrect'}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
     </div>
   );
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -16,6 +16,7 @@ export interface Play {
   is_correct: boolean;
   earned_score: number;
   played_at: string;
+  session_tag: string;
 }
 
 export interface User {


### PR DESCRIPTION
## Summary
- Group user's play history by session tag to organize review logs
- Display history entries with colored highlights for correct and incorrect answers
- Expose session tag in Play type for frontend grouping

## Testing
- `cd backend && go test -v -race ./...`
- `cd frontend && npm run lint`
- `cd frontend && npm run typecheck` *(fails: Missing script "typecheck")*
- `cd frontend && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a16d47144883239c3a1c025cf5cf9d