### PR TITLE
feat: add cursor-based word pagination

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,3 +1,5 @@
+import type { WordBatch } from '@/types';
+
 const API_BASE_URL =
   import.meta.env.VITE_API_BASE_URL || 'http://localhost:8180/api/v1';
 
@@ -41,11 +43,14 @@ export async function fetchRandomWords(
   count: number,
   language: string,
   difficulty: string,
-) {
-  const res = await fetch(
-    `${API_BASE_URL}/words/random?count=${count}&language=${language}&difficulty=${difficulty}`,
-    { credentials: 'include' },
-  );
+  cursor?: string,
+): Promise<WordBatch> {
+  const url = new URL(`${API_BASE_URL}/words/random`);
+  url.searchParams.set('count', String(count));
+  url.searchParams.set('language', language);
+  url.searchParams.set('difficulty', difficulty);
+  if (cursor) url.searchParams.set('cursor', cursor);
+  const res = await fetch(url.toString(), { credentials: 'include' });
   if (!res.ok) throw new Error('words failed');
   return res.json();
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -8,6 +8,11 @@ export interface Word {
   difficulty: string;
 }
 
+export interface WordBatch {
+  words: Word[];
+  next_cursor: string;
+}
+
 export interface Play {
   play_id: number;
   user_id: number;


### PR DESCRIPTION
## Summary
- add stateless cursor logic to word service and handler
- track cursor and prefetch words on the frontend game component
- expose cursor-ready API helper and types

## Testing
- `go test -v -race ./...` *(fails: command hung)*
- `npm run lint`
- `npm run typecheck` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68a183acba488323858d810516416f07