### PR TITLE
feat: replace base64 cursor with JWT

### DIFF
--- a/backend/configs/config.development.yaml
+++ b/backend/configs/config.development.yaml
@@ -10,3 +10,5 @@ redis:
   addr: "redis:6379"
   username: "default"
   password: "password"
+cursor:
+  secret: "changeme"

--- a/backend/configs/config.prod.yaml
+++ b/backend/configs/config.prod.yaml
@@ -1,2 +1,4 @@
 http:
   addr: ":80"
+cursor:
+  secret: "changeme"

--- a/backend/configs/config.yaml
+++ b/backend/configs/config.yaml
@@ -10,3 +10,5 @@ redis:
   addr: "redis:6379"
   username: "default"
   password: "password"
+cursor:
+  secret: "changeme"

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/gin-contrib/gzip v0.0.6
 	github.com/gin-gonic/gin v1.10.0
 	github.com/go-playground/validator/v10 v10.22.0
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.7.5
 	github.com/redis/go-redis/v9 v9.5.3

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -49,6 +49,8 @@ github.com/go-playground/validator/v10 v10.22.0/go.mod h1:dbuPbCMFw/DrkbEynArYaC
 github.com/goccy/go-json v0.9.7/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/goccy/go-json v0.10.3 h1:KZ5WoDbxAIgm2HNbYckL0se1fHD6rz5j4ywS6ebzDqA=
 github.com/goccy/go-json v0.10.3/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=

--- a/backend/internal/modules/play/wiring.go
+++ b/backend/internal/modules/play/wiring.go
@@ -11,7 +11,7 @@ import (
 
 // RegisterRoutes wires play handlers to the router.
 func RegisterRoutes(r *gin.RouterGroup, d *deps.Deps) {
-	wsvc := wordsvc.New(d.PG, d.RDB)
+	wsvc := wordsvc.New(d.PG, d.RDB, d.Cfg.Cursor.Secret)
 	svc := playsvc.New(d.PG)
 	h := handler.New(svc, wsvc)
 	r.GET("/history/:userID", h.History)

--- a/backend/internal/modules/word/wiring.go
+++ b/backend/internal/modules/word/wiring.go
@@ -10,7 +10,7 @@ import (
 
 // RegisterRoutes wires word handlers to the router.
 func RegisterRoutes(r *gin.RouterGroup, d *deps.Deps) {
-	svc := service.New(d.PG, d.RDB)
+	svc := service.New(d.PG, d.RDB, d.Cfg.Cursor.Secret)
 	h := handler.New(svc)
 	r.GET("/words/random", h.RandomWords)
 }

--- a/backend/internal/platform/config/config.go
+++ b/backend/internal/platform/config/config.go
@@ -5,6 +5,7 @@ type Config struct {
 	HTTP     HTTPConfig     `mapstructure:"http"`
 	Postgres PostgresConfig `mapstructure:"postgres"`
 	Redis    RedisConfig    `mapstructure:"redis"`
+	Cursor   CursorConfig   `mapstructure:"cursor"`
 }
 
 // HTTPConfig holds HTTP server related configuration.
@@ -26,4 +27,9 @@ type RedisConfig struct {
 	Addr     string `mapstructure:"addr"`
 	Username string `mapstructure:"username"`
 	Password string `mapstructure:"password"`
+}
+
+// CursorConfig holds JWT cursor settings.
+type CursorConfig struct {
+	Secret string `mapstructure:"secret"`
 }

--- a/backend/internal/platform/config/loader.go
+++ b/backend/internal/platform/config/loader.go
@@ -24,6 +24,7 @@ func Load() (*Config, error) {
 	v.SetDefault("redis.addr", "redis:6379")
 	v.SetDefault("redis.username", "default")
 	v.SetDefault("redis.password", "password")
+	v.SetDefault("cursor.secret", "changeme")
 
 	// config file
 	v.SetConfigName("config")


### PR DESCRIPTION
## Summary
- use JWT tokens for random word pagination cursor
- expose cursor secret in configuration and wiring

## Testing
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68a195be3e5c8323beb0f4f8626f6f1f