### PR TITLE
Optimize random word API using permutation index

### DIFF
--- a/backend/migrations/data/0002_fill_universe_index.down.sql
+++ b/backend/migrations/data/0002_fill_universe_index.down.sql
@@ -1,0 +1,1 @@
+TRUNCATE TABLE universe_index;

--- a/backend/migrations/data/0002_fill_universe_index.up.sql
+++ b/backend/migrations/data/0002_fill_universe_index.up.sql
@@ -1,0 +1,6 @@
+INSERT INTO universe_index(language_code, difficulty, rank, word_id)
+SELECT language_code,
+       difficulty,
+       ROW_NUMBER() OVER (PARTITION BY language_code, difficulty ORDER BY word_id) - 1 AS rank,
+       word_id
+FROM words;

--- a/backend/migrations/schema/002_create_universe_index.down.sql
+++ b/backend/migrations/schema/002_create_universe_index.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS universe_index;

--- a/backend/migrations/schema/002_create_universe_index.up.sql
+++ b/backend/migrations/schema/002_create_universe_index.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS universe_index (
+    language_code TEXT NOT NULL,
+    difficulty TEXT NOT NULL,
+    rank INTEGER NOT NULL,
+    word_id BIGINT NOT NULL,
+    PRIMARY KEY (language_code, difficulty, rank)
+);
+
+CREATE INDEX IF NOT EXISTS idx_universe_index_word ON universe_index(word_id);


### PR DESCRIPTION
## Summary
- Add permutation-based retrieval for random words using a fixed universe index
- Introduce `universe_index` table with helper data migration

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68a1d2adcd788323859ace1dc9994b24