### PR TITLE
Add daily universe index rebuild job

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hungdhv97/english-vocab-trainer/backend/internal/platform/config"
 	"github.com/hungdhv97/english-vocab-trainer/backend/internal/platform/db"
 	"github.com/hungdhv97/english-vocab-trainer/backend/internal/platform/deps"
+	"github.com/hungdhv97/english-vocab-trainer/backend/internal/platform/jobs"
 	"github.com/hungdhv97/english-vocab-trainer/backend/internal/platform/server"
 	"go.uber.org/zap"
 )
@@ -32,6 +33,7 @@ func main() {
 	defer rdb.Close()
 
 	d := &deps.Deps{Cfg: cfg, Log: logger, PG: pg, RDB: rdb}
+	jobs.Start(d)
 	r := server.NewRouter(d)
 
 	logger.Info("Starting server", zap.String("addr", cfg.HTTP.Addr))

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.7.5
 	github.com/redis/go-redis/v9 v9.5.3
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/viper v1.18.2
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.37.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -107,6 +107,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/redis/go-redis/v9 v9.5.3 h1:fOAp1/uJG+ZtcITgZOfYFmTKPE7n4Vclj1wZFgRciUU=
 github.com/redis/go-redis/v9 v9.5.3/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0b/CLO2V2M=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=

--- a/backend/internal/platform/jobs/jobs.go
+++ b/backend/internal/platform/jobs/jobs.go
@@ -1,0 +1,13 @@
+package jobs
+
+import (
+	"github.com/hungdhv97/english-vocab-trainer/backend/internal/platform/deps"
+	"github.com/robfig/cron/v3"
+)
+
+// Start initializes scheduled jobs using the provided dependencies.
+func Start(d *deps.Deps) {
+	c := cron.New()
+	registerUniverseIndex(c, d.PG)
+	c.Start()
+}

--- a/backend/internal/platform/jobs/universe_index.go
+++ b/backend/internal/platform/jobs/universe_index.go
@@ -1,0 +1,57 @@
+package jobs
+
+import (
+	"context"
+	"log"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/robfig/cron/v3"
+)
+
+// registerUniverseIndex schedules rebuilding the universe_index table
+// at 02:00 every day if the number of words has changed.
+func registerUniverseIndex(c *cron.Cron, db *pgxpool.Pool) {
+	c.AddFunc("0 2 * * *", func() { rebuildUniverseIndex(db) })
+}
+
+func rebuildUniverseIndex(db *pgxpool.Pool) {
+	ctx := context.Background()
+
+	var wordCount, indexCount int
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM words").Scan(&wordCount); err != nil {
+		log.Printf("count words: %v", err)
+		return
+	}
+	if err := db.QueryRow(ctx, "SELECT COUNT(*) FROM universe_index").Scan(&indexCount); err != nil {
+		log.Printf("count universe_index: %v", err)
+		return
+	}
+	if wordCount == indexCount {
+		return
+	}
+
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		log.Printf("begin tx: %v", err)
+		return
+	}
+	defer tx.Rollback(ctx)
+
+	if _, err := tx.Exec(ctx, "TRUNCATE universe_index"); err != nil {
+		log.Printf("truncate universe_index: %v", err)
+		return
+	}
+
+	if _, err := tx.Exec(ctx, `INSERT INTO universe_index(language_code, difficulty, rank, word_id)
+        SELECT language_code, difficulty,
+               ROW_NUMBER() OVER (PARTITION BY language_code, difficulty ORDER BY word_id) - 1 AS rank,
+               word_id
+        FROM words`); err != nil {
+		log.Printf("fill universe_index: %v", err)
+		return
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		log.Printf("commit universe_index: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- centralize job registration in `platform/jobs`
- schedule daily 02:00 universe index rebuild if words count changes
- start job scheduler from API main with a single call

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68a1dcdbb5288323aab47f308e6fd3da