### PR TITLE
feat: integrate shadcn chart on history screen

### DIFF
--- a/frontend/src/components/history/History.tsx
+++ b/frontend/src/components/history/History.tsx
@@ -8,14 +8,12 @@ interface ChartDatum extends HistoryPlay {
   time: string;
   cumulative: number;
 }
+import { LineChart, Line, XAxis, YAxis } from 'recharts';
 import {
-  LineChart,
-  Line,
-  XAxis,
-  YAxis,
-  Tooltip,
-  ResponsiveContainer,
-} from 'recharts';
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from '@/components/ui/chart';
 
 interface Props {
   userId: number;
@@ -61,6 +59,13 @@ export default function History({ userId }: Props) {
     });
   }, [plays]);
 
+  const chartConfig = {
+    cumulative: {
+      label: 'Score',
+      color: 'hsl(var(--chart-1))',
+    },
+  } as const;
+
   return (
     <div className="p-4 space-y-4">
       <Button
@@ -85,49 +90,63 @@ export default function History({ userId }: Props) {
           <h3 className="font-semibold">
             Session {new Date(plays[0].played_at).toLocaleString()}
           </h3>
-          <div className="w-full h-64">
-            <ResponsiveContainer width="100%" height="100%">
-              <LineChart data={chartData}>
-                <XAxis dataKey="time" />
-                <YAxis />
-                <Tooltip
-                  content={({ active, payload }) => {
-                    if (active && payload && payload.length) {
-                      const d = payload[0].payload as ChartDatum;
-                      return (
-                        <div
-                          className={`p-2 border rounded text-sm ${d.is_correct ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100' : 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-100'}`}
-                        >
-                          <div>{d.is_correct ? 'Correct' : 'Incorrect'}</div>
-                          {!d.is_correct && (
-                            <div>Correct word: {d.word.word_text}</div>
-                          )}
-                          <div>Your answer: {d.user_answer}</div>
-                          <div>Time: {d.time}s</div>
-                          <div>Score: {d.cumulative}</div>
-                        </div>
-                      );
-                    }
-                    return null;
-                  }}
-                />
-                <Line
-                  type="monotone"
-                  dataKey="cumulative"
-                  stroke="#8884d8"
-                  dot={({ cx, cy, payload }) => (
-                    <circle
-                      cx={cx}
-                      cy={cy}
-                      r={3}
-                      stroke="none"
-                      fill={payload.is_correct ? '#16a34a' : '#dc2626'}
-                    />
-                  )}
-                />
-              </LineChart>
-            </ResponsiveContainer>
-          </div>
+          <ChartContainer config={chartConfig} className="w-full h-64">
+            <LineChart data={chartData}>
+              <XAxis dataKey="time" />
+              <YAxis />
+              <ChartTooltip
+                content={({ active, payload }) => {
+                  if (active && payload && payload.length) {
+                    const d = payload[0].payload as ChartDatum;
+                    return (
+                      <ChartTooltipContent
+                        active={active}
+                        payload={payload}
+                        hideLabel
+                        hideIndicator
+                        className={
+                          d.is_correct
+                            ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100'
+                            : 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-100'
+                        }
+                        formatter={(_value, _name, item) => {
+                          const datum = item.payload as ChartDatum;
+                          return (
+                            <div className="space-y-1">
+                              <div>{
+                                datum.is_correct ? 'Correct' : 'Incorrect'
+                              }</div>
+                              {!datum.is_correct && (
+                                <div>Correct word: {datum.word.word_text}</div>
+                              )}
+                              <div>Your answer: {datum.user_answer}</div>
+                              <div>Time: {datum.time}s</div>
+                              <div>Score: {datum.cumulative}</div>
+                            </div>
+                          );
+                        }}
+                      />
+                    );
+                  }
+                  return null;
+                }}
+              />
+              <Line
+                type="monotone"
+                dataKey="cumulative"
+                stroke="var(--color-cumulative)"
+                dot={({ cx, cy, payload }) => (
+                  <circle
+                    cx={cx}
+                    cy={cy}
+                    r={3}
+                    stroke="none"
+                    fill={payload.is_correct ? '#16a34a' : '#dc2626'}
+                  />
+                )}
+              />
+            </LineChart>
+          </ChartContainer>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- replace Recharts wrappers with shadcn chart components in history view
- add chart configuration and styled tooltip for score timeline

## Testing
- `cd frontend && npm run lint`
- `npm run typecheck` (missing script)
- `npm test` (missing script)


------
https://chatgpt.com/codex/tasks/task_b_68a1ea402b388323b7287a4fe4715133